### PR TITLE
feat: adding customizable override in environment

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -33,9 +33,10 @@ let tokenTag = {
 let tokenHook = function (arg) {
     let request = arg.request
     let requestURI = new URL(request.getUrl())
-    if (requestURI.href.endsWith("/oauth2/v2.0/token")) {
+    let environment = request.getEnvironment()
+    let endsWith = (typeof environment.oauth_token_finder_endsWith === 'undefined') ? "/oauth2/v2.0/token" : environment.oauth_token_finder_endsWith
+    if (requestURI.href.endsWith(endsWith)) {
         let response = arg.response
-        let environment = request.getEnvironment()
         let responseBody = response.getBody()
         
         let responseContent = JSON.parse(responseBody.toString('utf-8'))


### PR DESCRIPTION
Small change to allow customization of token path as not all OAuth2 systems use "/oauth2/v2.0/token" as their path for tokens.  This way you can set up an environment variable called oauth_token_finder_endsWith to be the path to where to search for the token.